### PR TITLE
Add support for C-c stopping a process

### DIFF
--- a/crochet/_eventloop.py
+++ b/crochet/_eventloop.py
@@ -88,10 +88,27 @@ class EventualResult(object):
         returned on one call, additional calls will return/raise the same
         result.
         """
+        # The following hack is to prevent a deadlock when pressing C-c
+        # by doing the get in a while loop we ensure we release the GIL
+        # so that the SIGINT signal may be handled correctly.
+        timedout = lambda: False
+        if timeout is not None:
+            timeout_time = self._reactor.seconds() + timeout
+            timedout = lambda: self._reactor.seconds() > timeout_time
+        result = None
         try:
-            result = self._queue.get(timeout=timeout)
+            result = self._queue.get(timeout=0)
         except Empty:
-            raise TimeoutError()
+            if timeout == 0:
+                raise TimeoutError()
+        while not result and not timedout():
+            try:
+                result = self._queue.get(timeout=0.01)
+                break
+            except Empty:
+                pass
+            if timedout():
+                raise TimeoutError()
         self._result_retrieved = True
         self._queue.put(result) # allow next _result() call to get a value out
         return result

--- a/crochet/tests/test_api.py
+++ b/crochet/tests/test_api.py
@@ -5,11 +5,13 @@ Tests for the crochet APIs.
 from __future__ import absolute_import
 
 import threading
+import signal
 import time
 import gc
+import os
 import sys
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import TestCase, SynchronousTestCase
 from twisted.internet.defer import succeed, Deferred, fail, CancelledError
 from twisted.python.failure import Failure
 
@@ -18,6 +20,35 @@ from .test_setup import FakeReactor
 from .. import (_main, setup, in_reactor, retrieve_result, _store, no_setup,
                 run_in_reactor)
 
+
+def hang_process(event):
+    d = Deferred()
+    #Wait for process to be running
+    e = EventualResult(d)
+    t = threading.Thread(target=event.set)
+    t.start()
+    try:
+        e.wait()
+    except KeyboardInterrupt:
+        #Expected failure
+        t.join()
+        return
+
+class SynchronousEventualResultTests(SynchronousTestCase):
+    def test_control_c_is_possible(self):
+        """
+        Given the user presses control c, verify that
+        the process stops correctly
+        """
+        import multiprocessing
+        event = multiprocessing.Event()
+        event.clear()
+        proc = multiprocessing.Process(target=hang_process,
+                                       args=(event,))
+        proc.start()
+        event.wait()
+        os.kill(proc.pid, signal.SIGINT)
+        proc.join()
 
 class EventualResultTests(TestCase):
     """


### PR DESCRIPTION
- Add support for C-c stopping a process. This is done by calling get on the Queue (for retrieving results) in a loop.
- Add test for SIGINT

Not very happy with the way this while loop is implemented. Any tips on how this can be improved?
