### PR TITLE
A small bit of python3 friendliness to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ def get_crochet_version():
     version_module_path = os.path.join(crochet_module_path, "_version.py")
 
     # The version module contains a variable called __version__
-    exec(file(version_module_path).read())
-    return __version__
+    with open(version_module_path) as version_module:
+        exec(open(version_module).read())
+    return locals()["__version__"]
 
 
 setup(


### PR DESCRIPTION
The file() builtin no longer exists in python3. Use open() instead.
Also explicitly using the locals() dict to avoid a NameError.
