### PR TITLE
Fix explicit inclusion of Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: python
 
 env:
-    - TWISTED=Twisted==12.0 RUNTESTS=trial
-    - TWISTED=Twisted==12.1 RUNTESTS=trial
-    - TWISTED=Twisted==12.2 RUNTESTS=trial
-    - TWISTED=Twisted==12.3 RUNTESTS=trial
-    - TWISTED=Twisted==13.0 RUNTESTS=trial
-    - TWISTED=Twisted==13.1 RUNTESTS=trial
-    - TWISTED=Twisted==13.2 RUNTESTS=trial
+  - TWISTED=Twisted==12.0 RUNTESTS=trial
+  - TWISTED=Twisted==12.1 RUNTESTS=trial
+  - TWISTED=Twisted==12.2 RUNTESTS=trial
+  - TWISTED=Twisted==12.3 RUNTESTS=trial
+  - TWISTED=Twisted==13.0 RUNTESTS=trial
+  - TWISTED=Twisted==13.1 RUNTESTS=trial
+  - TWISTED=Twisted==13.2 RUNTESTS=trial
 
 python:
-    - 2.6
-    - 2.7
-    - pypy
+  - 2.6
+  - 2.7
+  - pypy
 
 matrix:
-    include:
-        python: 3.3
-        env: TWISTED=git+https://github.com/twisted/twisted.git RUNTESTS="python-m unittest discover"
+  include:
+    - python: 3.3
+      env: TWISTED=git+https://github.com/twisted/twisted.git RUNTESTS="python-m unittest discover"
 
 install:
-    - python setup.py --version
-    - pip install -q --no-use-wheel $TWISTED --use-mirrors
-    - python setup.py -q install
+  - python setup.py --version
+  - pip install -q --no-use-wheel $TWISTED --use-mirrors
+  - python setup.py -q install
 
 script: $RUNTESTS crochet.tests
 


### PR DESCRIPTION
The entry for matrix inclusion needs to be a list of key/value pairs.
