### PR TITLE
fix crochet crashing when MainThread isn't available when _shutdown module is loaded

### DIFF
--- a/crochet/_shutdown.py
+++ b/crochet/_shutdown.py
@@ -54,7 +54,7 @@ class FunctionRegistry(object):
 
 
 # This is... fragile. Not sure how else to do it though.
+_main_thread = [t for t in threading.enumerate() if t.name == "MainThread"]
 _registry = FunctionRegistry()
-_watchdog = Watchdog([t for t in threading.enumerate()
-                     if t.name == "MainThread"][0], _registry.run)
+_watchdog = Watchdog(_main_thread[0], _registry.run) if _main_thread else None
 register = _registry.register


### PR DESCRIPTION
This pull request fixes a situation where this bug causes projects using crotchet with [autonose](https://github.com/gfxmonk/autonose/) to not be able to rerun changed tests because crochet cannot find the MainThread.

    $ cat demo.py
    from crochet import setup, run_in_reactor, TimeoutError
    $ cat test_demo.py
    import unittest
    class Test(unittest.TestCase):
        def test_foo(self):
            import demo
    $ 0launch http://gfxmonk.net/dist/0install/autonose.xml &
    $ # ... wait for autonose to load and finish testing ...
    $ touch demo.py

Got:

    ======================================================================
    ERROR: test_foo (test_demo.Test)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/path/to/project/test_demo.py", line 4, in test_foo
        import demo
      File "/path/to/project/demo.py", line 1, in <module>
        from crochet import setup, run_in_reactor, TimeoutError
      File "/path/to/env/src/crochet/crochet/__init__.py", line 25, in <module>
        from ._shutdown import _watchdog, register
      File "/path/to/env/src/crochet/crochet/_shutdown.py", line 59, in <module>
        if t.name == "MainThread"][0], _registry.run)
    IndexError: list index out of range

    ----------------------------------------------------------------------
    Ran 1 test in 0.022s

    FAILED (errors=1)

Expected:

1. test reruns successfully