### PR TITLE
Add a shutdown_condition to setup

### DIFF
--- a/crochet/__init__.py
+++ b/crochet/__init__.py
@@ -22,19 +22,18 @@ else:
     # waitpid() is only necessary on POSIX:
     reapAllProcesses = lambda: None
 
-from ._shutdown import _watchdog, register
+from ._shutdown import registry, register
 from ._eventloop import (EventualResult, TimeoutError, EventLoop, _store,
                          ReactorStopped)
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-
 def _importReactor():
     from twisted.internet import reactor
     return reactor
-_main = EventLoop(_importReactor, register, startLoggingWithObserver,
-                  _watchdog, reapAllProcesses)
+_main = EventLoop(_importReactor, registry, startLoggingWithObserver,
+                  reapAllProcesses)
 setup = _main.setup
 no_setup = _main.no_setup
 run_in_reactor = _main.run_in_reactor

--- a/crochet/tests/test_api.py
+++ b/crochet/tests/test_api.py
@@ -988,7 +988,7 @@ class PublicAPITests(TestCase):
         call any methods on the objects it is created with.
         """
         c = EventLoop(lambda: None, lambda f, g: 1/0, lambda *args: 1/0,
-                      watchdog_thread=object(), reapAllProcesses=lambda: 1/0)
+                      reapAllProcesses=lambda: 1/0)
         del c
 
     def test_eventloop_api(self):
@@ -1005,10 +1005,9 @@ class PublicAPITests(TestCase):
         self.assertEqual(_main.run_in_reactor, run_in_reactor)
         self.assertEqual(_main.wait_for_reactor, wait_for_reactor)
         self.assertEqual(_main.wait_for, wait_for)
-        self.assertIdentical(_main._atexit_register, _shutdown.register)
+        self.assertIdentical(_main._atexit_registry, _shutdown.registry)
         self.assertIdentical(_main._startLoggingWithObserver,
                              startLoggingWithObserver)
-        self.assertIdentical(_main._watchdog_thread, _shutdown._watchdog)
 
     def test_eventloop_api_reactor(self):
         """


### PR DESCRIPTION
Resolves #78 

Add a `shutdown_condition` to `setup()` which can be used in environments that don't have a main thread with the expected name (or where you want to shutdown on some other condition).