### PR TITLE
Make main thread detection a bit less fragile

### DIFF
--- a/crochet/_shutdown.py
+++ b/crochet/_shutdown.py
@@ -55,6 +55,11 @@ class FunctionRegistry(object):
 
 # This is... fragile. Not sure how else to do it though.
 _registry = FunctionRegistry()
-_watchdog = Watchdog([t for t in threading.enumerate()
-                     if t.name == "MainThread"][0], _registry.run)
+_watchdog = Watchdog(
+    [
+        t for t in threading.enumerate()
+        if isinstance(t, threading._MainThread)
+    ][0],
+    _registry.run,
+)
 register = _registry.register

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -10,6 +10,9 @@ Bug fixes:
   wrapped in ``wait_for``) at import time if another thread holds the
   import lock. Thanks to Ken Struys for the patch.
 
+* Watchdog can now be properly created when the main thread is renamed,
+  e.g. in uWsgi processes. Thanks to Ben Picolo for the patch.
+
 1.2.0
 ^^^^^
 New features:


### PR DESCRIPTION
I think this should make the main thread detection a bit less fragile? Seems to work fine uwsgi worker processes, whereas the other version didn't =|

https://hg.python.org/cpython/file/2.7/Lib/threading.py#l1085 special class in thread lib just for the main thread

Edit: Heh, #81 is not entirely unlike my issue probably. Might want some combination of both of those pulls

Aha. Fixes #78 for uWsgi. :D I see now others had the same issue