### PR TITLE
Add destroy function that essentially undoes everything setup does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _trial_temp
 
 # Editor files
 *~
+*.swp
 
 # Distribution
 dist

--- a/crochet/__init__.py
+++ b/crochet/__init__.py
@@ -27,11 +27,14 @@ retrieve_result = _store.retrieve
 in_reactor = _main.in_reactor
 DeferredResult = EventualResult
 
+def get_reactor():
+    return _main._reactor
+
 # Backwards compatibility with 1.1.0 and earlier:
 wait_for_reactor = _main.wait_for_reactor
 
 __all__ = ["setup", "run_in_reactor", "EventualResult", "TimeoutError",
-           "destroy", "retrieve_result", "no_setup", "wait_for",
+           "destroy", "get_reactor", "retrieve_result", "no_setup", "wait_for",
            "ReactorStopped", "__version__",
            # Backwards compatibility:
            "DeferredResult", "in_reactor", "wait_for_reactor",

--- a/crochet/_eventloop.py
+++ b/crochet/_eventloop.py
@@ -438,7 +438,7 @@ class EventLoop(object):
             raise RuntimeError("destroy() is meant to be called only after "
                                "setup() or no_setup() to reset crochet's "
                                "global state.")
-        if not self._use_global_reactor:
+        if self._use_global_reactor:
             raise RuntimeError("Cannot call destroy if using global reactor. "
                                "Call setup() with use_global_reactor=False.")
 

--- a/crochet/_util.py
+++ b/crochet/_util.py
@@ -29,14 +29,11 @@ def synchronized(method):
 
 def get_twisted_reactor(use_global):
     """
-    When you do `from twisted.internet import reactor`, twisted "installs" a
-    reactor. All this really means it that it looks at your platform to
-    determine which reactor (epoll, select, or poll) you should use, creates
-    a singleton of that type of reactor, and puts it in sys.modules as
-    `twisted.internet.reactor`.
+    If `use_global=False`, this recreates logic in `twisted.internet.default`
+    to choose between reactors, but bypasses "installing" the reactor as a
+    global singleton.
 
-    This recreates logic in `twisted.internet.default` to choose between
-    reactors, but bypasses "installing" the reactor as a global singleton.
+    If `use_global=True`, this returns the globally installed twisted reactor.
     """
     if use_global:
         from twisted.internet import reactor

--- a/crochet/_util.py
+++ b/crochet/_util.py
@@ -1,8 +1,18 @@
 """
 Utility functions and classes.
 """
-
+import sys
 from functools import wraps
+
+from twisted.python.runtime import platform
+
+reapAllProcesses = lambda: None
+if platform.type == "posix":
+    try:
+        from twisted.internet.process import reapAllProcesses
+    except (SyntaxError, ImportError):
+        if sys.version_info < (3, 3, 0):
+            raise
 
 
 def synchronized(method):
@@ -15,3 +25,34 @@ def synchronized(method):
             return method(self, *args, **kwargs)
     synced.synchronized = True
     return synced
+
+
+def get_twisted_reactor(use_global):
+    """
+    When you do `from twisted.internet import reactor`, twisted "installs" a
+    reactor. All this really means it that it looks at your platform to
+    determine which reactor (epoll, select, or poll) you should use, creates
+    a singleton of that type of reactor, and puts it in sys.modules as
+    `twisted.internet.reactor`.
+
+    This recreates logic in `twisted.internet.default` to choose between
+    reactors, but bypasses "installing" the reactor as a global singleton.
+    """
+    if use_global:
+        from twisted.internet import reactor
+        return reactor
+
+    try:
+        if platform.isLinux():
+            try:
+                from twisted.internet.epollreactor import EPollReactor as _r
+            except ImportError:
+                from twisted.internet.pollreactor import PollReactor as _r
+        elif platform.getType() == 'posix' and not platform.isMacOSX():
+            from twisted.internet.pollreactor import PollReactor as _r
+        else:
+            from twisted.internet.selectreactor import SelectReactor as _r
+    except ImportError:
+        from twisted.internet.selectreactor import SelectReactor as _r
+
+    return _r()

--- a/crochet/tests/test_shutdown.py
+++ b/crochet/tests/test_shutdown.py
@@ -10,8 +10,8 @@ import time
 
 from twisted.trial.unittest import TestCase
 
-from crochet._shutdown import (Watchdog, FunctionRegistry, _watchdog, register,
-                               _registry)
+from crochet._shutdown import (Watchdog, FunctionRegistry, get_watchdog_thread,
+                               register, _registry)
 from ..tests import crochet_directory
 
 
@@ -27,7 +27,8 @@ class ShutdownTests(TestCase):
         program = """\
 import threading, sys
 
-from crochet._shutdown import register, _watchdog
+from crochet._shutdown import register, get_watchdog_thread
+_watchdog = get_watchdog_thread()
 _watchdog.start()
 
 end = False
@@ -84,6 +85,7 @@ sys.exit()
         The module exposes a shutdown thread that will call a global
         registry's run(), and a register function tied to the global registry.
         """
+        _watchdog = get_watchdog_thread()
         self.assertIsInstance(_registry, FunctionRegistry)
         self.assertEqual(register, _registry.register)
         self.assertIsInstance(_watchdog, Watchdog)

--- a/crochet/tests/test_util.py
+++ b/crochet/tests/test_util.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from twisted.trial.unittest import TestCase
 
 from .._util import synchronized
+from .._util import get_twisted_reactor
 
 
 class FakeLock(object):
@@ -67,3 +68,12 @@ class SynchronizedTests(TestCase):
         A method wrapped with @synchronized is marked as synchronized.
         """
         self.assertEqual(Lockable.check.synchronized, True)
+
+
+class GetTwistedReactorTests(TestCase):
+    """
+    Tests for choosing the right twisted reactor based on different platforms
+    """
+    def test_use_global_reactor(self):
+        from twisted.internet import reactor
+        self.assertEqual(get_twisted_reactor(use_global=True), reactor)


### PR DESCRIPTION
@itamarst hi! If you have some free time I'd greatly appreciate some feedback on this PR.

I've been trying to update crochet so it can be used both pre and post-fork in a forking server like uWSGI. The approach I've taken is to add a `destroy` function that stops all of crochet's threads. [Here](https://gist.github.com/mjbryant/958be332874b5c622848b622a756cdb7) is an example of how this'll be used.

The main change I had to make was to allow crochet to use its own copy of twisted's reactor, which allows it to be stopped and recreated at will. This obviously precludes other applications from accessing the reactor that crochet is controlling except through crochet's APIs, but for a lot of cases (like ours) this won't be a problem.

The final thing I have to figure out is that the [logging test](https://github.com/mjbryant/crochet/blob/master/crochet/tests/test_setup.py#L366) is flaky. Some runs the log lines come back out of order. Have any suggestions?