### PR TITLE
Update the CI and README for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,30 @@
 language: python
-
-env:
-  # Oldest supported version:
-  - TWISTED=Twisted==16.0
-  # Latest Twisted:
-  - TWISTED=Twisted
-
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy
+cache: pip
+dist: xenial
 
 install:
-  - python setup.py --version
-  - pip install -q $TWISTED flake8 pylint
-  - python setup.py -q install
+ - pip install --upgrade pip setuptools
+ - pip install tox-travis
+
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "pypy"
+
+env:
+  - TWISTED="16"
+  - TWISTED="latest"
 
 script:
-  - trial crochet.tests
-  - flake8 crochet
-  - pylint crochet
+  - tox
+
+matrix:
+  include:
+    - python: "3.5"
+      env: TOXENV=lint3
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ API and features
            :target: http://travis-ci.org/itamarst/crochet
            :alt: Build Status
 
-Crochet supports Python 2.7, 3.4, 3.5 and 3.6 as well as PyPy.
+Crochet supports Python 2.7, 3.4, 3.5, 3.6, and 3.7 as well as PyPy.
 
 Crochet provides the following basic APIs:
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,13 @@
 What's New
 ==========
 
+1.10.0
+^^^^^^
+
+New features:
+
+* Added support for Python 3.7.
+
 1.9.0
 ^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,8 @@ deps = flake8
 basepython = python3.5
 commands = flake8 crochet
            pylint crochet
+
+[travis:env]
+TWISTED =
+  16: twisted-16
+  latest: twisted-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py27, py35, lint3
+envlist = lint3,{py27,py34,py35,py36,py37,pypy}-{twisted-16,twisted-latest}
 usedevelop = true
 
 [testenv]
+deps =
+    twisted-16: Twisted==16.0
+    twisted-latest: Twisted
 commands =
     {envpython} setup.py --version
     pip install .


### PR DESCRIPTION
This updates the Tox configuration, Travis CI configuration, and notes Python 3.7 is supported in the README and classifiers.

Fixes: #117 