### PR TITLE
Fix a timeout overflow bug in 32-bit machines

### DIFF
--- a/crochet/_eventloop.py
+++ b/crochet/_eventloop.py
@@ -194,7 +194,7 @@ class EventualResult(object):
                 DeprecationWarning,
                 stacklevel=3)
             # Queue.get(None) won't get interrupted by Ctrl-C...
-            timeout = sys.maxsize
+            timeout = 2 ** 28
         self._result_set.wait(timeout)
         # In Python 2.6 we can't rely on the return result of wait(), so we
         # have to check manually:

--- a/crochet/_eventloop.py
+++ b/crochet/_eventloop.py
@@ -5,6 +5,7 @@ Expose Twisted's event loop to threaded programs.
 from __future__ import absolute_import
 
 import select
+import sys
 import threading
 import weakref
 import warnings
@@ -193,7 +194,7 @@ class EventualResult(object):
                 DeprecationWarning,
                 stacklevel=3)
             # Queue.get(None) won't get interrupted by Ctrl-C...
-            timeout = 2**31
+            timeout = sys.maxsize
         self._result_set.wait(timeout)
         # In Python 2.6 we can't rely on the return result of wait(), so we
         # have to check manually:

--- a/crochet/_eventloop.py
+++ b/crochet/_eventloop.py
@@ -5,7 +5,6 @@ Expose Twisted's event loop to threaded programs.
 from __future__ import absolute_import
 
 import select
-import sys
 import threading
 import weakref
 import warnings


### PR DESCRIPTION
Fixes #125 

Use "sys.maxsize" to override unlimited timeouts, instead of the definite number "2**31" that can lead to overflows.